### PR TITLE
Fixed "Get File Using Absolute Windows Source" test for Python2&3 on Windows

### DIFF
--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from robot.utils import is_string, unic
+from robot.utils import is_string, unic, is_unicode
 
 import time
 import ntpath

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -167,8 +167,8 @@ class SFTPClient(AbstractSFTPClient):
         path = path.encode(self._encoding)
         if not self._is_windows_path(path):
             path = self._client.normalize(path)
-        if not is_string(path):
-            path = unic(path)
+        if not is_unicode(path):
+            path = path.decode(self._encoding)
         return path
 
     def _is_windows_path(self, path):


### PR DESCRIPTION
Running tests on Windows, there was one test failing with both Python 2 and 3. 
The absolute path for Windows was not correctly constructed.